### PR TITLE
add tox version pinning for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,6 @@ matrix:
     - python: 3.6
       env: TOXENV=black-check
 install:
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install virtualenv==15.2.0; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install virtualenv==15.2.0 tox==3.1.3; fi
     - pip install tox
 script: tox


### PR DESCRIPTION
*Issue #, if available:* #4 

*Description of changes:*
We need to pin `tox` as well now for Python 3.3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
