### PR TITLE
Allow skipping whitespace cleanup

### DIFF
--- a/test/unit/test_base64_stream.py
+++ b/test/unit/test_base64_stream.py
@@ -157,6 +157,22 @@ def test_base64io_decode(bytes_to_generate, bytes_per_round, number_of_rounds, t
 @pytest.mark.parametrize(
     "bytes_to_generate, bytes_per_round, number_of_rounds, total_bytes_to_expect", build_test_cases()
 )
+def test_base64io_decode_str(bytes_to_generate, bytes_per_round, number_of_rounds, total_bytes_to_expect):
+    plaintext_source = os.urandom(bytes_to_generate)
+    plaintext_b64 = io.StringIO(base64.b64encode(plaintext_source).decode('ascii'))
+    plaintext_wrapped = Base64IO(plaintext_b64)
+
+    test = b""
+    for _round in range(number_of_rounds):
+        test += plaintext_wrapped.read(bytes_per_round)
+
+    assert len(test) == total_bytes_to_expect
+    assert test == plaintext_source[:total_bytes_to_expect]
+
+
+@pytest.mark.parametrize(
+    "bytes_to_generate, bytes_per_round, number_of_rounds, total_bytes_to_expect", build_test_cases()
+)
 def test_base64io_encode_partial(bytes_to_generate, bytes_per_round, number_of_rounds, total_bytes_to_expect):
     plaintext_source = os.urandom(bytes_to_generate)
     plaintext_stream = io.BytesIO(plaintext_source)
@@ -292,6 +308,14 @@ def build_whitespace_testcases():
 @pytest.mark.parametrize("plaintext_source, b64_plaintext_with_whitespace, read_bytes", build_whitespace_testcases())
 def test_base64io_decode_with_whitespace(plaintext_source, b64_plaintext_with_whitespace, read_bytes):
     with Base64IO(io.BytesIO(b64_plaintext_with_whitespace)) as decoder:
+        test = decoder.read(read_bytes)
+
+    assert test == plaintext_source[:read_bytes]
+
+
+@pytest.mark.parametrize("plaintext_source, b64_plaintext_with_whitespace, read_bytes", build_whitespace_testcases())
+def test_base64io_decode_with_whitespace_str(plaintext_source, b64_plaintext_with_whitespace, read_bytes):
+    with Base64IO(io.StringIO(b64_plaintext_with_whitespace.decode('ascii'))) as decoder:
         test = decoder.read(read_bytes)
 
     assert test == plaintext_source[:read_bytes]

--- a/test/unit/test_base64_stream.py
+++ b/test/unit/test_base64_stream.py
@@ -14,6 +14,7 @@
 from __future__ import division
 
 import base64
+import binascii
 import functools
 import io
 import math
@@ -314,11 +315,29 @@ def test_base64io_decode_with_whitespace(plaintext_source, b64_plaintext_with_wh
 
 
 @pytest.mark.parametrize("plaintext_source, b64_plaintext_with_whitespace, read_bytes", build_whitespace_testcases())
+def test_base64io_decode_with_whitespace_ignored(plaintext_source, b64_plaintext_with_whitespace, read_bytes):
+    try:
+        with Base64IO(io.BytesIO(b64_plaintext_with_whitespace), ignore_whitespace=False) as decoder:
+            test = decoder.read(read_bytes)
+    except binascii.Error as e:
+        assert e.args[0] == 'Incorrect padding'
+
+
+@pytest.mark.parametrize("plaintext_source, b64_plaintext_with_whitespace, read_bytes", build_whitespace_testcases())
 def test_base64io_decode_with_whitespace_str(plaintext_source, b64_plaintext_with_whitespace, read_bytes):
     with Base64IO(io.StringIO(b64_plaintext_with_whitespace.decode('ascii'))) as decoder:
         test = decoder.read(read_bytes)
 
     assert test == plaintext_source[:read_bytes]
+
+
+@pytest.mark.parametrize("plaintext_source, b64_plaintext_with_whitespace, read_bytes", build_whitespace_testcases())
+def test_base64io_decode_with_whitespace_ignored_str(plaintext_source, b64_plaintext_with_whitespace, read_bytes):
+    try:
+        with Base64IO(io.StringIO(b64_plaintext_with_whitespace.decode('ascii')), ignore_whitespace=False) as decoder:
+            test = decoder.read(read_bytes)
+    except binascii.Error as e:
+        assert e.args[0] == 'Incorrect padding'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Refs #21

Allow skipping whitespace cleanup.  Defaults to the existing behavior. The flag allows skipping whitespace filtering of the input stream for performance reasons.

This is a suggested fix to the first item in the referenced issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
