### PR TITLE
remove use of deprecated hypothesis features

### DIFF
--- a/test/functional/test_f_base64_stream.py
+++ b/test/functional/test_f_base64_stream.py
@@ -30,10 +30,8 @@ HYPOTHESIS_SETTINGS = hypothesis.settings(
         hypothesis.HealthCheck.hung_test,
         hypothesis.HealthCheck.large_base_example,
     ),
-    timeout=hypothesis.unlimited,
     deadline=None,
     max_examples=1000,
-    max_iterations=1500,
 )
 BINARY = hypothesis_strategies.binary()
 

--- a/test/requirements/modern
+++ b/test/requirements/modern
@@ -1,4 +1,4 @@
-hypothesis
+hypothesis>=3.56.0
 mock
 pytest>=3.3.1
 pytest-cov


### PR DESCRIPTION
*Description of changes:*
* timeout: https://hypothesis.readthedocs.io/en/master/changes.html#v3-16-0
* max_iterations: https://hypothesis.readthedocs.io/en/master/changes.html#v3-56-0


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
