### PR TITLE
GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci_static-analysis.yaml
+++ b/.github/workflows/ci_static-analysis.yaml
@@ -1,0 +1,4 @@
+# This workflow runs static analysis checks on pull requests.
+name: Static Analysis
+
+on: [pull_request]

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -1,0 +1,4 @@
+# This workflow runs tests on pull requests.
+name: Static Analysis
+
+on: [pull_request]

--- a/.github/workflows/gitflow_pr-router.yaml
+++ b/.github/workflows/gitflow_pr-router.yaml
@@ -1,0 +1,26 @@
+# This workflow routes pull requests to the correct branch
+name: pull request router
+
+on: [pull_request]
+
+jobs:
+  send to develop:
+    # Move any PRs to master that do *not* come from development
+    if: github.base_ref == 'master' && github.head_ref != 'development'
+    runs-on: ubuntu-latest
+    steps:
+      - name: switch
+        uses: actions/github-script@0.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.pulls.update({
+              pull_number: context.issue.number,
+              base: 'development',
+              ...context.repo
+            })
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              body: 'Moving target to development branch.',
+              ...context.repo
+            })

--- a/.github/workflows/gitflow_promote-to-master.yaml
+++ b/.github/workflows/gitflow_promote-to-master.yaml
@@ -1,0 +1,22 @@
+# This workflow promotes pushes to development to master
+name: Promote development to master
+
+on:
+  push:
+    branches:
+      - development
+
+jobs:
+  promote-to-master:
+    name: Promote dev branch to master
+    runs-on: ubuntu-latest
+    steps:
+      - name: promote
+        uses: vsoch/pull-request-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_PREFIX: development
+          PULL_REQUEST_BRANCH: master
+          PULL_REQUEST_TITLE: Promote development to master
+          PULL_REQUEST_BODY: |
+            Automatic promotion from development to master.

--- a/.github/workflows/ops_pr-post-merge.yaml
+++ b/.github/workflows/ops_pr-post-merge.yaml
@@ -1,0 +1,14 @@
+# This workflow runs any cleanup or other behavior after a PR has been merged.
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: clean up source branch
+        uses: jessfraz/branch-cleanup-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ops_publish-to-pypi.yaml
+++ b/.github/workflows/ops_publish-to-pypi.yaml
@@ -1,0 +1,43 @@
+# This workflow publishes to PyPI whenever we publish a GitHub release.
+name: Publish to PyPI
+
+on:
+  releases:
+    types:
+      - published
+
+jobs:
+  test-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.x
+      - run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade -r ci-requirements.txt
+      - name: publish to test-PyPI
+        env:
+          TOXENV: test-release
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
+        run: tox -- -vv
+  release:
+    # Only run if test-release succeeded.
+    needs: test-release
+    # I'm putting this as a separate job rather than another step
+    # so that we can be certain that there is no cross-contamination.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.x
+      - run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade -r ci-requirements.txt
+      - name: publish to test-PyPI
+        env:
+          TOXENV: release
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: tox -- -vv

--- a/.github/workflows/ops_publish-to-pypi.yaml
+++ b/.github/workflows/ops_publish-to-pypi.yaml
@@ -36,7 +36,7 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install --upgrade -r ci-requirements.txt
-      - name: publish to test-PyPI
+      - name: publish to PyPI
         env:
           TOXENV: release
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/tox.ini
+++ b/tox.ini
@@ -262,19 +262,24 @@ commands =
 [testenv:test-release]
 basepython = {[testenv:default-python]basepython}
 skip_install = true
+setenv =
+    TWINE_USERNAME = __token__
 deps =
     {[testenv:build]deps}
     twine
 commands =
     {[testenv:build]commands}
-    twine upload --skip-existing --repository testpypi dist/*
+    twine upload --skip-existing dist/*
 
 [testenv:release]
 basepython = {[testenv:default-python]basepython}
 skip_install = true
+setenv =
+    TWINE_REPOSITORY_URL = https://test.pypi.org/legacy/
+    TWINE_USERNAME = __token__
 deps =
     {[testenv:build]deps}
     twine
 commands =
     {[testenv:build]commands}
-    twine upload --skip-existing --repository pypi dist/*
+    twine upload --skip-existing dist/*

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,12 @@ commands = pytest --basetemp={envtmpdir} -l --cov base64io {posargs}
 
 [testenv]
 sitepackages = False
+passenv =
+    # Pass through PyPI variables to tell secrets-helper where to look
+    PYPI_SECRET_ARN TEST_PYPI_SECRET_ARN \
+    # Pass through twine password -- remove this once secrets-helper is fixed
+    # https://github.com/awslabs/secrets-helper/issues/15
+    TWINE_PASSWORD
 deps =
     py26: -rtest/requirements/legacy
     py27: -rtest/requirements/modern


### PR DESCRIPTION
*Issue #, if available:* starting on #29 

*Description of changes:*

This adds the initial components for most of the workflows we need.

I intentionally left the testing workflows empty for now. This should bootstrap triggering them to run on the next PR, and I'll flesh them out there.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
