### PR TITLE
chore: update pylintrc config with new Python3-only checks

### DIFF
--- a/src/pylintrc
+++ b/src/pylintrc
@@ -3,6 +3,10 @@
 disable =
     bad-continuation,  # we let black handle this
     ungrouped-imports,  # we let black handle this
+    # All below are disabled because we need to support Python 2
+    useless-object-inheritance,
+    raise-missing-from,
+    super-with-arguments,
 
 [BASIC]
 # Allow function names up to 50 characters

--- a/test/pylintrc
+++ b/test/pylintrc
@@ -2,14 +2,18 @@
 # Disabling messages that we either don't care about
 # for tests or are necessary to break for tests.
 #
-# C0103 : invalid-name (we prefer long, descriptive, names for tests)
-# C0111 : missing-docstring (we don't write docstrings for tests)
-# E1101 : no-member (raised on patched objects with mock checks)
-# R0801 : duplicate-code (unit tests for similar things tend to be similar)
-# W0212 : protected-access (raised when calling _ methods)
-# W0621 : redefined-outer-name (raised when using pytest-mock)
-# W0613 : unused-argument (raised when patches are needed but not called)
-disable = C0103, C0111, E1101, R0801, W0212, W0621, W0613
+disable =
+    invalid-name,  # we prefer long, descriptive, names for tests
+    missing-docstring,  # we don't write docstrings for tests
+    no-member,  # raised on patched objects with mock checks
+    duplicate-code,  # unit tests for similar things tend to be similar
+    protected-access,  # raised when calling _ methods
+    redefined-outer-name,  # raised when using pytest-mock
+    unused-argument,  # raised when patches and fixtures are needed but not called
+    # All below are disabled because we need to support Python 2
+    useless-object-inheritance,
+    raise-missing-from,
+    super-with-arguments,
 
 [DESIGN]
 max-args = 10


### PR DESCRIPTION
*Description of changes:*

Recent `pylint` updates added some additional checks that tell you to do things that only work in Python 3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
