### PR TITLE
chore: address mypy and pylint changes

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,7 +29,7 @@ def get_version():
     return _release
 
 
-project = u"base64io"
+project = u"base64io"  # pylint: disable=redundant-u-string-prefix
 version = get_version()
 release = get_release()
 
@@ -52,7 +52,7 @@ templates_path = ["_templates"]
 source_suffix = ".rst"  # The suffix of source filenames.
 master_doc = "index"  # The master toctree document.
 
-copyright = u"%s, Amazon" % datetime.now().year  # pylint: disable=redefined-builtin
+copyright = u"%s, Amazon" % datetime.now().year  # pylint: disable=redefined-builtin,redundant-u-string-prefix
 
 # List of directories, relative to source directory, that shouldn't be searched
 # for source files.

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,10 @@ branch = True
 show_missing = True
 
 [mypy]
+# mypy is upset that readlines and writelines are
+# methods as compared to stand alone functions,
+# as this overrides the first argument with self
+disable_error_code = override
 ignore_missing_imports = True
 
 [tool:pytest]

--- a/src/base64io/__init__.py
+++ b/src/base64io/__init__.py
@@ -23,7 +23,16 @@ LOGGER_NAME = "base64io"
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from types import TracebackType  # noqa pylint: disable=unused-import
-    from typing import IO, AnyStr, Iterable, List, Literal, Optional, Type, Union  # noqa pylint: disable=unused-import
+    from typing import (  # type: ignore[attr-defined] # noqa pylint: disable=unused-import
+        IO,
+        AnyStr,
+        Iterable,
+        List,
+        Literal,
+        Optional,
+        Type,
+        Union,
+    )
 except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
@@ -292,7 +301,7 @@ class Base64IO(io.IOBase):
         # Remove whitespace from read data and attempt to read more data to get the desired
         # number of bytes.
 
-        if any([char in data for char in string.whitespace.encode("utf-8")]):
+        if any(char in data for char in string.whitespace.encode("utf-8")):
             data = self._read_additional_data_removing_whitespace(data, _bytes_to_read)
 
         results = io.BytesIO()

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,3 +2,6 @@ hypothesis>=3.56.0
 mock
 pytest>=3.3.1
 pytest-cov
+# mypy (from tox) outputs coverage data in a coverage 4.x format
+coverage==4.5.4
+typing>=3.6.2

--- a/test/unit/test_base64_stream.py
+++ b/test/unit/test_base64_stream.py
@@ -93,7 +93,7 @@ def test_passthrough_methods_file(tmpdir, method_name, mode, expected):
     source = tmpdir.join("source")
     source.write("some data")
 
-    with open(str(source), mode) as reader:
+    with open(str(source), mode) as reader:  # pylint: disable=unspecified-encoding
         with Base64IO(reader) as b64:
             test = getattr(b64, method_name)()
 

--- a/test/unit/test_base64io.py
+++ b/test/unit/test_base64io.py
@@ -41,7 +41,11 @@ def test_file():
 
 @pytest.mark.parametrize(
     "source, expected",
-    (("asdf", b"asdf"), (b"\x00\x01\x02\x03", b"\x00\x01\x02\x03"), (u"\u1111\u2222", b"\xe1\x84\x91\xe2\x88\xa2")),
+    (
+        ("asdf", b"asdf"),
+        (b"\x00\x01\x02\x03", b"\x00\x01\x02\x03"),
+        (u"\u1111\u2222", b"\xe1\x84\x91\xe2\x88\xa2"),  # pylint: disable=redundant-u-string-prefix
+    ),
 )
 def test_to_bytes(source, expected):
     assert base64io._to_bytes(source) == expected

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36,37},
+    py{27,34,35,36,37,38,39},
     bandit, doc8, readme,
     mypy-py{2,3},
     flake8, pylint,

--- a/tox.ini
+++ b/tox.ini
@@ -34,9 +34,9 @@ commands = pytest --basetemp={envtmpdir} -l --cov base64io {posargs}
 basepython = {[testenv:default-python]basepython}
 deps =
     # mypy outputs coverage data in a coverage 4.x format
-    coverage<5.0.0
-    mypy
-    mypy_extensions
+    coverage==4.5.4
+    mypy==0.812
+    mypy_extensions==0.4.3
     typing>=3.6.2
 commands =
     python -m mypy \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* `mypy` and `pylint` have both been changed recently to better enforce best practices. 
I have accepted one of these changes (using generators, `src/base64io/__init__.py:304`), but appropriately ignored the others.

In `mypy`'s case, there is a breaking change. At this time, I recommend we pin ourselves to `mypy` == 4.5.4 until our other python libraries move forward as well (the `aws-encryption-sdk-cli` in particular). 

Finally, I changed the testing requirements so that a single command can run all the tests and static checkers (`tox`). By pinning `coverage` and `typing` in both the tests and `tox` created static checker environments, `mypy` and other static checkers can reference the same coverage file, preventing needless `coverage` exceptions when the `.coverage` can not be read.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
