### PR TITLE
chore(pylint): ignore consider-using-f-string

### DIFF
--- a/src/pylintrc
+++ b/src/pylintrc
@@ -7,6 +7,7 @@ disable =
     useless-object-inheritance,
     raise-missing-from,
     super-with-arguments,
+    consider-using-f-string
 
 [BASIC]
 # Allow function names up to 50 characters

--- a/test/pylintrc
+++ b/test/pylintrc
@@ -14,6 +14,7 @@ disable =
     useless-object-inheritance,
     raise-missing-from,
     super-with-arguments,
+    consider-using-f-string,
 
 [DESIGN]
 max-args = 10

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,6 +1,6 @@
 hypothesis>=3.56.0
 mock
-pytest>=6.2.5
+pytest>=3.3.1
 pytest-cov
 # mypy (from tox) outputs coverage data in a coverage 4.x format
 coverage==4.5.4

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,7 +1,7 @@
 hypothesis>=3.56.0
 mock
 pytest>=3.3.1
-pytest-cov
+pytest-cov>=2.12.1
 # mypy (from tox) outputs coverage data in a coverage 4.x format
 coverage==4.5.4
 typing>=3.6.2

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,7 +1,7 @@
 hypothesis>=3.56.0
 mock
-pytest>=3.3.1
-pytest-cov>=2.12.1
+pytest>=6.2.5
+pytest-cov
 # mypy (from tox) outputs coverage data in a coverage 4.x format
 coverage==4.5.4
 typing>=3.6.2


### PR DESCRIPTION
*Issue #, if available:* Static analysis failing

*Description of changes:* See git comment for pylint.

Concerning `pytest-cov`: py38 & py39 were using pytest-cov == 2.10.1 while all the other pyXy were using 2.12.1, even py27. This made parallel testing of all tox envs fail with an sqlite/coverage error. Fixing all of them to use 2.12.1 fixed that. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
