### PR TITLE
chore: Remove data_files section from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
     maintainer="Amazon Web Services",
     long_description=readme(),
     keywords="base64 stream",
-    data_files=["README.rst", "CHANGELOG.rst", "LICENSE"],
     license="Apache License 2.0",
     install_requires=[],
     classifiers=[


### PR DESCRIPTION
## Connected with https://github.com/aws/base64io-python/issues/38 and https://github.com/aws/base64io-python/issues/41

Installing the `base64io` via `requirements.txt` in a Python project that we're running leads to README.rst, CHANGELOG.rst and LICENSE files from `base64io` replacing our files with the same names.

This PR aims to solve this problem, by not distributing these files with the installation - there seem to be no real need in this - LICENSE is distributed by default, while README and CHANGELOG are accessible via githun.com repository.

_reproduced on upstream from #41_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
