### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Each line is a file pattern followed by one or more owners.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default code owner for everything is our aws-crypto-tools group
+*       @aws/aws-crypto-tools


### PR DESCRIPTION
*Issue #, if available:* We should be able to approve First Time contributors to run CI actions, like in https://github.com/aws/base64io-python/pull/41, but we cannot, possibly b/c we do not have a CODEOWNERS file.

*Description of changes:* add a code owner file.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
