### PR TITLE
fix: python3.12 testing and linting

### DIFF
--- a/.github/workflows/ci_static-analysis.yaml
+++ b/.github/workflows/ci_static-analysis.yaml
@@ -15,7 +15,16 @@ jobs:
       fail-fast: false
       matrix:
         category:
+          - mypy-py3
+          - bandit
+          - doc8
           - readme
+          - docs
+          - flake8
+          - pylint
+          - flake8-tests
+          - pylint-tests
+          - black-check
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/ci_static-analysis.yaml
+++ b/.github/workflows/ci_static-analysis.yaml
@@ -1,4 +1,4 @@
-# This workflow runs static analysis checks on pull requests.l
+# This workflow runs static analysis checks on pull requests.
 name: static analysis
 
 on:

--- a/.github/workflows/ci_static-analysis.yaml
+++ b/.github/workflows/ci_static-analysis.yaml
@@ -1,4 +1,4 @@
-# This workflow runs static analysis checks on pull requests.
+# This workflow runs static analysis checks on pull requests.l
 name: static analysis
 
 on:
@@ -29,7 +29,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.x
+          python-version: 3.11
+          # Python 3.12 has pip issues, use 3.11
       - run: |
           python -m pip install --upgrade pip
           pip install --upgrade -r ci-requirements.txt

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -24,12 +24,13 @@ jobs:
             architecture: x86
           - os: macos-latest
             architecture: x64
-        python:
-          - 3.8
-          - 3.9
-          - "3.10"
-          - "3.11"
-          - "3.12"
+        major: 3
+        minor:
+          - 8
+          - 9
+          - 10
+          - 11
+          - 12
         category:
           # Runs the base test environment
           - py
@@ -37,12 +38,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python }}
+          python-version: '${{ matrix.major }}.${{ matrix.minor }}'
           architecture: ${{ matrix.platform.architecture }}
       - run: |
           python -m pip install --upgrade pip
           pip install --upgrade -r ci-requirements.txt
       - name: run test
         env:
-          TOXENV: '${{ matrix.category }}${{ matrix.python }}'
+          TOXENV: '${{ matrix.category }}${{ matrix.major }}${{ matrix.minor }}'
         run: tox -- -vv

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -24,7 +24,8 @@ jobs:
             architecture: x86
           - os: macos-latest
             architecture: x64
-        major: 3
+        major:
+          - 3
         minor:
           - 8
           - 9

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -44,5 +44,5 @@ jobs:
           pip install --upgrade -r ci-requirements.txt
       - name: run test
         env:
-          TOXENV: ${{ matrix.category }}
+          TOXENV: '${{ matrix.category }}${{ matrix.python }}'
         run: tox -- -vv

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -30,7 +30,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - 3.x
         category:
           # Runs the base test environment
           - py

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -29,6 +29,8 @@ jobs:
           - 3.9
           - "3.10"
           - "3.11"
+          - "3.12"
+          - 3.x
         category:
           # Runs the base test environment
           - py

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Getting Started
 
 :class:`base64io.Base64IO` has no dependencies other than the standard library and and should
 work with any version of Python greater than 2.6.
-We test it on CPython 3.8, 3.9, 3.10, & 3.11.
+We test it on CPython 3.8, 3.9, 3.10, 3.11, & 3.12.
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Getting Started
 :class:`base64io.Base64IO` has no dependencies other than the standard library and and should
 work with any version of Python greater than 2.6.
 We test it on CPython 3.8, 3.9, 3.10, & 3.11.
- 
+
 Installation
 ============
 

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,1 +1,2 @@
+setuptools
 tox==3.24.5

--- a/src/base64io/__init__.py
+++ b/src/base64io/__init__.py
@@ -159,8 +159,7 @@ class Base64IO(io.IOBase):
             ):
                 return True
             return False
-        else:
-            return method()
+        return method()
 
     def writable(self):
         # type: () -> bool

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,4 @@
+setuptools
 hypothesis>=3.56.0
 mock
 pytest>=3.3.1

--- a/test/unit/test_base64_stream.py
+++ b/test/unit/test_base64_stream.py
@@ -59,7 +59,7 @@ def test_base64io_always_false_methods(method_name):
     assert not getattr(test, method_name)()
 
 
-@pytest.mark.parametrize("method_name, args", (("fileno", ()), ("seek", (None,)), ("tell", ()), ("truncate", ())))
+@pytest.mark.parametrize("method_name, args", (("fileno", ()), ("seek", (4,)), ("tell", ()), ("truncate", ())))
 def test_unsupported_methods(method_name, args):
     test = Base64IO(io.BytesIO())
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311},
+    py{38,39,310,311,312},
     bandit, doc8, readme,
     mypy-py3,
     flake8, pylint,
@@ -13,7 +13,8 @@ envlist =
 # linters-tests :: Runs all linters over all tests.
 
 [testenv:default-python]
-basepython = python3
+# 3.12 has pip issues, default to 3.11
+basepython = python3.11
 
 [testenv:base-command]
 commands = pytest --basetemp={envtmpdir} -l --cov base64io {posargs}
@@ -26,7 +27,9 @@ passenv =
     # Pass through twine password -- remove this once secrets-helper is fixed
     # https://github.com/awslabs/secrets-helper/issues/15
     TWINE_PASSWORD
-deps = -rtest/requirements.txt
+deps =
+     -rtest/requirements.txt
+     py312: pip>=23.3.1
 commands = pytest --basetemp={envtmpdir} -l --cov base64io {posargs}
 
 # mypy


### PR DESCRIPTION
*Issue #, if available:* Test Python 3.12 in CI

*Description of changes:*
1. Everywhere: Address Linting finds
2. In tests: Python3.12 throws a TypeError on `IO.seek(None)`, so use `IO.seek(4)`
3. tox & GitHub: test on Python3.12 by fixing pip via a conditional in tox.ini
4. ci-requirements & test/requirements: require setuptools for Python3.12


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
