### PR TITLE
chore(CI): upgrade mac os version to macos-13 

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -22,7 +22,7 @@ jobs:
           # x86 builds are only meaningful for Windows
           - os: windows-latest
             architecture: x86
-          - os: macos-12
+          - os: macos-13
             architecture: x64
         major:
           - 3

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
-sphinx>=1.3.0
+sphinx>=1.3.0,<7.4.7
 sphinx_rtd_theme


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- macos-12 is deprecated and CI will not run on masos-12
- Changed settings to require CI check for macos-13 from macos-12
- sphinx contains breaking change after `8.0.0` and CI fails so limited it until `<7.4.7`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
